### PR TITLE
summon, bail warrant specific schema and nia case specific schema created

### DIFF
--- a/docs/Case/schemas/case-nia.json
+++ b/docs/Case/schemas/case-nia.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "http://dristi.pucar.org/schemas/casenia.json",
+  "$comment": "definition of the schema for the information required for NIA Case",
+  "$version": "0.1.0",
+  "chequeDetails": {
+    "number": {
+      "type": "string",
+      "pattern": "^\\d{6}$",
+      "description": "6 digit number"
+    },
+    "amount": {
+      "type": "string",
+      "pattern": "^\\d{1,12}$",
+      "description": "up to 12 digit number"
+    },
+    "payeeName": {
+      "type": "string",
+      "pattern": "^[a-zA-Z]{1,100}$",
+      "description": "sting having a max of 100 alphabets. no numbers"
+    },
+    "payeeBank": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{1,200}$",
+      "description": "sting having a max of 200 alphanumeric characters"
+    },
+    "payerName": {
+      "type": "string",
+      "pattern": "^[a-zA-Z]{1,100}$",
+      "description": "sting having a max of 100 alphabets. no numbers"
+    },
+    "payerBank": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{1,200}$",
+      "description": "sting having a max of 200 alphanumeric characters"
+    },
+    "payerBankIFSC": {
+      "type": "string",
+      "minLength": 11,
+      "maxLength": 11,
+      "pattern": "^[a-zA-Z]{4}0[a-zA-Z0-9]{6}$",
+      "description": "11 character string. first for alphabets. fifth 0. last six mostly numeric, but alphanumeric allowed"
+    },
+    "cheque": {
+      "type": "string",
+      "format": "uuid",
+      "description": "uuid of the document for bounced cheque, stored in the document array in main case object"
+    },
+    "issueDate" : {
+      "type": "string",
+      "format": "date"
+    },
+    "depositDate" : {
+      "type": "string",
+      "format": "date"
+    },
+    "insufficientFunds": {
+      "type": "boolean"
+    },
+    "returnMemo": {
+      "type": "string",
+      "format": "uuid",
+      "description": "uuid of the document for cheque return memo, stored in the document array in main case object"
+    },
+    "comments": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{0,400}$",
+      "description": "any additional comments. max of 400 alphanumeric characters"
+    }
+  },
+  "debtDetails": {
+    "debtLiability": {
+      "type": "boolean"
+    },
+    "nature": {
+      "type": "string"
+    },
+    "liability": {
+      "enum": ["full", "partial"]
+    },
+    "amount": {
+      "type": "string",
+      "pattern": "^\\d{1,12}$",
+      "description": "up to 12 digit number"
+    },
+    "debtLiabilityProof": {
+      "type": "boolean"
+    },
+    "docProof": {
+      "type": "string",
+      "format": "uuid",
+      "description": "uuid of the document for liability proof, stored in the document array in main case object"
+    },
+    "comments": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{0,400}$",
+      "description": "any additional comments. max of 400 alphanumeric characters"
+    }
+  },
+  "demandNoticeDetails": {
+    "isTimelyNotice": {
+      "type": "boolean"
+    },
+    "dispatchMode": {
+      "enum": ["post","in-person"]
+    },
+    "issueDate": {
+      "type": "string",
+      "format": "date"
+    },
+    "dispatchDate": {
+      "type": "string",
+      "format": "date"
+    },
+    "noticeDoc": {
+      "type": "string",
+      "format": "uuid",
+      "description": "uuid of the document for demand notice, stored in the document array in main case object"
+    },
+    "dispatchProofDoc": {
+      "type": "string",
+      "format": "uuid",
+      "description": "uuid of the document for proof of dispatch of demand notice, stored in the document array in main case object"
+    },
+    "serviceDate": {
+      "type": "string",
+      "format": "date"
+    },
+    "isServiceProof": {
+      "type": "boolean"
+    },
+    "serviceProofDoc": {
+      "type": "string",
+      "format": "uuid",
+      "description": "uuid of the document for proof of service of demand notice, stored in the document array in main case object"
+    },
+    "replyDate": {
+      "type": "string",
+      "format": "date"
+    },
+    "replyProofDoc": {
+      "type": "string",
+      "format": "uuid",
+      "description": "uuid of the document for proof of reply of demand notice, stored in the document array in main case object"
+    },
+    "isPaidAfterNotice": {
+      "type": "boolean",
+      "description": "did the payer pay within 15 days after the notice or not"
+    },
+    "arrualDate": {
+      "type": "string",
+      "format": "date",
+      "description": "Date when the 15 days from service of demand notice was complete (date of accrual of cause of action). Auto filled based on 15 days from service date"
+    }
+  },
+  "delayAppDetails": {
+    "isDelayed": {
+      "type": "boolean"
+    },
+    "reason": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{0,400}$",
+      "description": "any additional comments. max of 400 alphanumeric characters"
+    },
+    "document": {
+      "type": "string",
+      "format": "uuid",
+      "description": "uuid of the document for delay condonation application, stored in the document array in main case object"
+    }
+  }
+}

--- a/docs/task/schemas/task-bail.json
+++ b/docs/task/schemas/task-bail.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "http://dristi.pucar.org/schemas/bail.json",
+  "$comment": "definition of the schema for issuing a bail. bail date, type, amount, case number etc. will be available in the task object itself",
+  "$version": "0.1.0",
+
+  "bailId": "123 456 7890",
+  "respondentDetails":
+  {
+    "name" : {
+      "type": "string",
+      "pattern": "^[a-zA-Z]{1,100}$",
+      "description": "sting having a max of 100 alphabets. no numbers"
+    },
+    "age" : {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 120,
+      "description": "age in years and will accept decimals so age can be 10.5 meaning 10 years 6 months"
+    },
+    "address": {
+      "type": "string",
+      "pattern": "^.{1,400}$",
+      "description": "sting having a max of 400 characters and matches any character (including newline characters)"
+    },
+    "phone" : {
+      "type": "string",
+      "pattern": "^\\+?[0-9\\-() ]+$"
+    },
+    "gender": {
+      "type": "string",
+      "pattern": "^[a-zA-Z]{1,16}$",
+      "description": "string value to a max of 16 alphabets",
+      "examples" : ["male", "female","transgender"]
+    }
+  },
+  "caseDetails":
+  {
+    "title": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{1,512}$",
+      "description": "sting having a max of 512 alphanumeric characters"
+    },
+    "year": {
+      "type": "integer",
+      "minimum": 1900,
+      "maximum": 9999,
+      "description": "year the case was logged"
+    },
+    "judgeName": {
+      "type": "string",
+      "pattern": "^[a-zA-Z]{1,100}$",
+      "description": "sting having a max of 100 alphabets. no numbers"
+    },
+    "courtName": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{1,124}$",
+      "description": "sting having a max of 200 alphanumeric characters"
+    },
+    "courtAddress": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{1,200}$",
+      "description": "sting having a max of 200 alphanumeric characters"
+    },
+    "courtPhone": {
+      "type": "string",
+      "pattern": "^\\+?[0-9\\-() ]+$"
+    }
+  }
+}

--- a/docs/task/schemas/task-summon.json
+++ b/docs/task/schemas/task-summon.json
@@ -19,7 +19,7 @@
     "name" : {
       "type": "string",
       "pattern": "^[a-zA-Z]{1,100}$",
-      "description": "sting having a max of 100 alphabets. no numbers"
+      "description": "string having a max of 100 alphabets. no numbers"
     },
     "age" : {
       "type": "number",
@@ -30,7 +30,7 @@
     "address": {
       "type": "string",
       "pattern": "^.{1,400}$",
-      "description": "sting having a max of 400 characters and matches any character (including newline characters)"
+      "description": "string having a max of 400 characters and matches any character (including newline characters)"
     },
     "phone" : {
       "type": "string",
@@ -39,7 +39,7 @@
     "gender": {
       "type": "string",
       "pattern": "^[a-zA-Z]{1,16}$",
-      "description": "string value to a max of 16 alphabets",
+      "description": "string having a max of 16 alphabets",
       "examples" : ["male", "female","transgender"]
     }
   },
@@ -48,12 +48,12 @@
     "name" : {
       "type": "string",
       "pattern": "^[a-zA-Z]{1,100}$",
-      "description": "sting having a max of 100 alphabets. no numbers"
+      "description": "string having a max of 100 alphabets. no numbers"
     },
     "address": {
       "type": "string",
       "pattern": "^.{1,400}$",
-      "description": "sting having a max of 400 characters and matches any character (including newline characters)"
+      "description": "string having a max of 400 characters and matches any character (including newline characters)"
     }
   },
   "caseDetails":
@@ -81,7 +81,7 @@
     "courtName": {
       "type": "string",
       "pattern": "^[a-zA-Z0-9]{1,124}$",
-      "description": "sting having a max of 200 alphanumeric characters"
+      "description": "string having a max of 124 alphanumeric characters"
     },
     "courtAddress": {
       "type": "string",

--- a/docs/task/schemas/task-summon.json
+++ b/docs/task/schemas/task-summon.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "http://dristi.pucar.org/schemas/summon.json",
+  "$comment": "definition of the schema for issuing a summon. date, type, amount, case number etc. will be available in the task object itself",
+  "$version": "0.1.0",
+  "summonDetails":
+  {
+    "summonId": {
+      "type" : "string",
+      "description": "alphanumeric string representing the summon ID"
+    },
+    "issueDate": {
+      "type" : "string",
+      "format": "date"
+    }
+  },
+  "respondentDetails":
+  {
+    "name" : {
+      "type": "string",
+      "pattern": "^[a-zA-Z]{1,100}$",
+      "description": "sting having a max of 100 alphabets. no numbers"
+    },
+    "age" : {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 120,
+      "description": "age in years and will accept decimals so age can be 10.5 meaning 10 years 6 months"
+    },
+    "address": {
+      "type": "string",
+      "pattern": "^.{1,400}$",
+      "description": "sting having a max of 400 characters and matches any character (including newline characters)"
+    },
+    "phone" : {
+      "type": "string",
+      "pattern": "^\\+?[0-9\\-() ]+$"
+    },
+    "gender": {
+      "type": "string",
+      "pattern": "^[a-zA-Z]{1,16}$",
+      "description": "string value to a max of 16 alphabets",
+      "examples" : ["male", "female","transgender"]
+    }
+  },
+  "complainantDetails":
+  {
+    "name" : {
+      "type": "string",
+      "pattern": "^[a-zA-Z]{1,100}$",
+      "description": "sting having a max of 100 alphabets. no numbers"
+    },
+    "address": {
+      "type": "string",
+      "pattern": "^.{1,400}$",
+      "description": "sting having a max of 400 characters and matches any character (including newline characters)"
+    }
+  },
+  "caseDetails":
+  {
+    "title": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{1,512}$",
+      "description": "sting having a max of 512 alphanumeric characters"
+    },
+    "year": {
+      "type": "integer",
+      "minimum": 1900,
+      "maximum": 9999,
+      "description": "year the case was logged"
+    },
+    "hearingDate": {
+      "type" : "string",
+      "format": "date"
+    },
+    "judgeName": {
+      "type": "string",
+      "pattern": "^[a-zA-Z]{1,100}$",
+      "description": "sting having a max of 100 alphabets. no numbers"
+    },
+    "courtName": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{1,124}$",
+      "description": "sting having a max of 200 alphanumeric characters"
+    },
+    "courtAddress": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{1,200}$",
+      "description": "sting having a max of 200 alphanumeric characters"
+    },
+    "courtPhone": {
+      "type": "string",
+      "pattern": "^\\+?[0-9\\-() ]+$"
+    }
+  },
+  "deliveryChannel" : [
+    {
+      "name" : {
+        "type": "string",
+        "pattern": "^[a-zA-Z]{1,32}$",
+        "description": "sting having a max of 32 alphabets. no numbers"
+      },
+      "status": {
+        "type": "string",
+        "pattern": "^[a-zA-Z\\s]+$",
+        "description": "mostly alphabets but can have white space"
+      },
+      "statusChangeDate": {
+        "type": "string",
+        "format": "date"
+      },
+      "fees": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 5000,
+        "description": "putting some random number for max limit for now"
+      }
+    }
+  ]
+}

--- a/docs/task/schemas/task-warrant.json
+++ b/docs/task/schemas/task-warrant.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "http://dristi.pucar.org/schemas/warrant.json",
+  "$comment": "definition of the schema for issuing a warrant",
+  "$version": "0.1.0",
+  "warrantId": "123 456 7890",
+  "respondentDetails":
+  {
+    "name" : {
+      "type": "string",
+      "pattern": "^[a-zA-Z]{1,100}$",
+      "description": "sting having a max of 100 alphabets. no numbers"
+    },
+    "age" : {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 120,
+      "description": "age in years and will accept decimals so age can be 10.5 meaning 10 years 6 months"
+    },
+    "address": {
+      "type": "string",
+      "pattern": "^.{1,400}$",
+      "description": "sting having a max of 400 characters and matches any character (including newline characters)"
+    },
+    "phone" : {
+      "type": "string",
+      "pattern": "^\\+?[0-9\\-() ]+$"
+    },
+    "gender": {
+      "type": "string",
+      "pattern": "^[a-zA-Z]{1,16}$",
+      "description": "string value to a max of 16 alphabets",
+      "examples" : ["male", "female","transgender"]
+    }
+  },
+  "caseDetails":
+  {
+    "title": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{1,512}$",
+      "description": "sting having a max of 512 alphanumeric characters"
+    },
+    "year": {
+      "type": "integer",
+      "minimum": 1900,
+      "maximum": 9999,
+      "description": "year the case was logged"
+    },
+    "hearingDate": {
+      "type" : "string",
+      "format": "date"
+    },
+    "judgeName": {
+      "type": "string",
+      "pattern": "^[a-zA-Z]{1,100}$",
+      "description": "sting having a max of 100 alphabets. no numbers"
+    },
+    "courtName": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{1,124}$",
+      "description": "sting having a max of 200 alphanumeric characters"
+    },
+    "courtAddress": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{1,200}$",
+      "description": "sting having a max of 200 alphanumeric characters"
+    },
+    "courtPhone": {
+      "type": "string",
+      "pattern": "^\\+?[0-9\\-() ]+$"
+    }
+  },
+  "deliveryChannel" : [
+    {
+      "name" : {
+        "type": "string",
+        "pattern": "^[a-zA-Z]{1,32}$",
+        "description": "sting having a max of 32 alphabets. no numbers"
+      },
+      "status": {
+        "type": "string",
+        "pattern": "^[a-zA-Z\\s]+$",
+        "description": "mostly alphabets but can have white space"
+      },
+      "statusChangeDate": {
+        "type": "string",
+        "format": "date"
+      },
+      "fees": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 5000,
+        "description": "putting some random number for max limit for now"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
dristi\docs\task\schemas - schemas added for summon, bail and warrant for loading to MDMS and doing data validation 

dristi\docs\case\schemas - schema added for NIA specific case 